### PR TITLE
style: aplica gradiente amarelo-verde suave na seção hero

### DIFF
--- a/src/app/components/hero/Hero.module.css
+++ b/src/app/components/hero/Hero.module.css
@@ -6,7 +6,7 @@
   padding: clamp(20px, 4vw, 36px);
   border-radius: 18px;
   border: 1px solid rgba(0, 0, 0, 0.06);
-  background: linear-gradient(135deg, #000000 0%, #f4ebdd 60%, #efe6d8 100%);
+  background: linear-gradient(135deg, #f9f7e8 0%, #e8f5e0 100%);
 }
 
 .row {


### PR DESCRIPTION
- Substitui gradiente escuro por cores pastéis (#f9f7e8 → #e8f5e0)
- Melhora contraste e legibilidade da seção principal